### PR TITLE
Minor issue while using sync cache

### DIFF
--- a/bug_test.js
+++ b/bug_test.js
@@ -1,0 +1,33 @@
+var lru_cache = require('./cachejs').lru;
+// Sync cache - 100 items, expire after 5 seconds
+var cache = lru_cache(100,5);
+newTest(cache);
+
+function newTest(lruCache) {
+	lruCache.put('a', 'aa');
+	lruCache.put('b', 'ab');
+	lruCache.put('c', 'ac');
+	lruCache.put('d', 'ad');
+	assert(lruCache.get('a'),'aa');
+	assert(lruCache.get('b'),'ab');
+	assert(lruCache.get('c'),'ac');
+	assert(lruCache.get('d'),'ad');
+
+	setTimeout(function() {
+			lruCache.put('a','aa'); // This fails
+			lruCache.put('b', 'ab');
+			lruCache.put('c', 'ac');
+			lruCache.put('d', 'ad');
+			assert(lruCache.get('a'),'aa');
+			assert(lruCache.get('b'),'ab');
+			assert(lruCache.get('c'),'ac');
+			assert(lruCache.get('d'),'ad');
+		}, 6000);
+}
+
+function assert(expected, actual) {
+    if (actual.toString() != expected.toString())  {
+        console.log('Failed test  Expecting: ' + expected + ' but receiving: ' + actual);
+    }
+}
+

--- a/lib/lru_cache.js
+++ b/lib/lru_cache.js
@@ -59,10 +59,12 @@ function getCache(maxLen, expire, store, emptySlots, lookup){
     function bridge(index, val) {
         var prev = val.prev;
         var next = val.next;
-        //the neighbour below has to point to the neighbour above:
-        store[prev].next = next;
-        //and the neighbour above to the neighbour below:
-        store[next].prev = prev;
+        if (prev) {
+            //the neighbour below has to point to the neighbour above:
+            store[prev].next = next;
+            //and the neighbour above to the neighbour below:
+            store[next].prev = prev;
+        }
     }
 
     //move the value to the top of the list:


### PR DESCRIPTION
Thank you for writing an awesome caching framework. I was playing with it and noticed that the adding to the LRU cache after the items have expired results in an error. I have added a test to reproduce this issue. 

I wrote a temporary fix ( to work around this issue). Please feel free to reject this patch and fix it correctly, as I have not had time to look at the full root cause of this bug.

Thanks.
